### PR TITLE
Fixes bug in nrml04_parser, adds YC to mfd.__init__

### DIFF
--- a/hmtk/faults/mfd/__init__.py
+++ b/hmtk/faults/mfd/__init__.py
@@ -47,5 +47,6 @@
 
 from hmtk.faults.mfd.anderson_luco_area_mmax import AndersonLucoAreaMmax
 from hmtk.faults.mfd.anderson_luco_arbitrary import AndersonLucoArbitrary
-#from hmtk.faults.mfd.youngs_coppersmith import YoungsCoppersmith
+from hmtk.faults.mfd.youngs_coppersmith import (YoungsCoppersmithExponential,
+    YoungsCoppersmithCharacteristic)
 from hmtk.faults.mfd.characteristic import Characteristic

--- a/hmtk/parsers/source_model/nrml04_parser.py
+++ b/hmtk/parsers/source_model/nrml04_parser.py
@@ -203,9 +203,6 @@ class nrmlSourceModelParser(BaseSourceModelParser, FaultGeometryParserMixin):
         [mfd_elem] = _xpath(src_elem, ('.//nrml:truncGutenbergRichterMFD | '
                                        './/nrml:incrementalMFD'))
         
-        if len(mfd_elem) == 0:
-            return None
-        
         value_set = False
         if mfd_elem.tag == '{%s}truncGutenbergRichterMFD' % (nrml.NAMESPACE):
             mfd = models.TGRMFD()


### PR DESCRIPTION
i) Adds YoungsCoppersmithExponential and YoungsCoppersmithCharacteristic to hmtk/faults/mfd/**init**.py.

ii) Fixes bug in nrml04 source model parser by removing list length check when reading mfd
