### PR TITLE
Fix python-decorator import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ a minute of your time to read the disclaimer below.
 The main dependencies of this library are the following:
 * csv
 * numpy
+* python-decorator
 * hazardlib (this is part of the OpenQuake suite)
 * nrmllib (this is part of the OpenQuake suite)
 

--- a/hmtk/registry.py
+++ b/hmtk/registry.py
@@ -45,7 +45,7 @@
 
 import collections
 import functools
-from hmtk.decorator import decorator
+from decorator import decorator
 
 
 class Registry(collections.OrderedDict):


### PR DESCRIPTION
Fix an import of python-decorator. (which was still working on already deployed versions of hmtk because of a stale pyc file).

Please, remember to remove the decorator.pyc file in your local hmtk folder.
