### PR TITLE
Removes oq-nrmllib dependencies

### DIFF
--- a/hmtk/parsers/source_model/base.py
+++ b/hmtk/parsers/source_model/base.py
@@ -68,7 +68,9 @@ class BaseSourceModelParser(object):
             raise IOError('File not found')
 
     @abc.abstractmethod
-    def read_file(self, mesh_spacing):
+    def read_file(self, identifier, mfd_spacing=0.1,
+            simple_mesh_spacing=1.0, complex_mesh_spacing=4.0,
+            area_discretization=10.):
         """
         Return an instance of the class :class:`mtkSourceModel`
         """

--- a/hmtk/sources/area_source.py
+++ b/hmtk/sources/area_source.py
@@ -205,31 +205,6 @@ class mtkAreaSource(object):
             warnings.warn('Source %s (%s) has fewer than 5 events'
                           % (self.id, self.name))
 
-    def create_oqnrml_source(self, use_defaults=False):
-        '''
-        Converts the source model into  an instance of the :class:
-        openquake.nrmllib.models.AreaSource
-
-        :param bool use_defaults:
-            If set to true, will use put in default values for magitude
-            scaling relation, rupture aspect ratio, nodal plane distribution
-            or hypocentral depth distribution where missing. If set to False
-            then value errors will be raised when information is missing.
-        '''
-        area_geometry = models.AreaGeometry(self.geometry.wkt,
-                                            self.upper_depth,
-                                            self.lower_depth)
-        return models.AreaSource(
-            self.id,
-            self.name,
-            self.trt,
-            area_geometry,
-            conv.render_mag_scale_rel(self.mag_scale_rel, use_defaults),
-            conv.render_aspect_ratio(self.rupt_aspect_ratio, use_defaults),
-            conv.render_mfd(self.mfd),
-            conv.render_npd(self.nodal_plane_dist, use_defaults),
-            conv.render_hdd(self.hypo_depth_dist, use_defaults))
-
     def create_oqhazardlib_source(self, tom, mesh_spacing, area_discretisation,
             use_defaults=False):
         """
@@ -242,11 +217,13 @@ class mtkAreaSource(object):
         :param float mesh_spacing:
             Mesh spacing
         """
+        if not self.mfd:
+            raise ValueError("Cannot write to hazardlib without MFD")
         return AreaSource(
             self.id,
             self.name,
             self.trt,
-            conv.mfd_to_hazardlib(self.mfd),
+            self.mfd,
             mesh_spacing,
             conv.mag_scale_rel_to_hazardlib(self.mag_scale_rel, use_defaults),
             conv.render_aspect_ratio(self.rupt_aspect_ratio, use_defaults),

--- a/hmtk/sources/complex_fault_source.py
+++ b/hmtk/sources/complex_fault_source.py
@@ -223,43 +223,18 @@ class mtkComplexFaultSource(object):
             warnings.warn('Source %s (%s) has fewer than 5 events'
                           % (self.id, self.name))
 
-    def create_oqnrml_source(self, use_defaults=False):
-        '''
-        Converts the complex source into an instance of the :class:
-        openquake.nrmllib.models.ComplexFaultSource
-
-        :param bool use_defaults:
-            If set to True, will input default values of rupture aspect
-            ratio and magnitude scaling relation where missing. If false,
-            value errors will be raised if information is missing.
-        '''
-        if not isinstance(self.rake, float):
-            raise ValueError('Cannot create complex source - rake is missing!')
-
-        # Render complex geometry to linestrings
-        complex_geometry = conv.complex_trace_to_wkt_linestring(
-            self.fault_edges)
-
-        return models.ComplexFaultSource(
-            self.id,
-            self.name,
-            self.trt,
-            complex_geometry,
-            conv.render_mag_scale_rel(self.mag_scale_rel, use_defaults),
-            conv.render_aspect_ratio(self.rupt_aspect_ratio, use_defaults),
-            conv.render_mfd(self.mfd),
-            self.rake)
-
     def create_oqhazardlib_source(self, tom, mesh_spacing, use_defaults=False):
         """
         Creates an instance of the source model as :class:
         openquake.hazardlib.source.complex_fault.ComplexFaultSource
         """
+        if not self.mfd:
+            raise ValueError("Cannot write to hazardlib without MFD")
         return ComplexFaultSource(
             self.id,
             self.name,
             self.trt,
-            conv.mfd_to_hazardlib(self.mfd),
+            self.mfd,
             mesh_spacing,
             conv.mag_scale_rel_to_hazardlib(self.mag_scale_rel, use_defaults),
             conv.render_aspect_ratio(self.rupt_aspect_ratio, use_defaults),

--- a/hmtk/sources/point_source.py
+++ b/hmtk/sources/point_source.py
@@ -267,30 +267,6 @@ class mtkPointSource(object):
             warnings.warn('Source %s (%s) has fewer than 5 events'
                           % (self.id, self.name))
 
-    def create_oqnrml_source(self, use_defaults=False):
-        '''
-        Converts the source model into  an instance of the :class:
-        openquake.nrmllib.models.PointSource
-        :param bool use_defaults:
-            If set to true, will use put in default values for magitude
-            scaling relation, rupture aspect ratio, nodal plane distribution
-            or hypocentral depth distribution where missing. If set to False
-            then value errors will be raised when information is missing.
-        '''
-        point_geometry = models.PointGeometry(self.geometry.wkt2d,
-                                              self.upper_depth,
-                                              self.lower_depth)
-        return models.PointSource(
-            self.id,
-            self.name,
-            self.trt,
-            point_geometry,
-            conv.render_mag_scale_rel(self.mag_scale_rel, use_defaults),
-            conv.render_aspect_ratio(self.rupt_aspect_ratio, use_defaults),
-            conv.render_mfd(self.mfd),
-            conv.render_npd(self.nodal_plane_dist, use_defaults),
-            conv.render_hdd(self.hypo_depth_dist, use_defaults))
-
     def create_oqhazardlib_source(self, tom, mesh_spacing, use_defaults=False):
         """
         Converts the point source model into an instance of the :class:
@@ -302,11 +278,13 @@ class mtkPointSource(object):
             or hypocentral depth distribution where missing. If set to False
             then value errors will be raised when information is missing.
         """
+        if not self.mfd:
+            raise ValueError("Cannot write to hazardlib without MFD")
         return PointSource(
             self.id,
             self.name,
             self.trt,
-            conv.mfd_to_hazardlib(self.mfd),
+            self.mfd,
             mesh_spacing,
             conv.mag_scale_rel_to_hazardlib(self.mag_scale_rel, use_defaults),
             conv.render_aspect_ratio(self.rupt_aspect_ratio, use_defaults),

--- a/hmtk/sources/source_conversion_utils.py
+++ b/hmtk/sources/source_conversion_utils.py
@@ -48,7 +48,6 @@
 # -*- coding: utf-8 -*-
 import abc
 from decimal import Decimal
-from openquake.nrmllib import models
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib.geo.nodalplane import NodalPlane
 from openquake.hazardlib import mfd
@@ -57,156 +56,6 @@ from openquake.hazardlib.scalerel.base import BaseMSR
 from openquake.hazardlib.scalerel.wc1994 import WC1994
 
 SCALE_RELS = get_available_scalerel()
-
-
-class MFDConverter(object):
-    '''
-    Abstract base class for converting the mfd between the openquake.hazardlib
-    implementation and the openquake.nrmllib implementation
-    '''
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
-    def convert(self, mag_freq_dist):
-        '''
-        Converts the input magnitude frequency distribution in the
-        openquake.hazardlib format to the openquake.nrmllib.models format
-
-        :param mag_freq_dist:
-            Magnitude frequency distribution as either instance of the :class:
-            openquake.hazardlib.mfd
-
-        :returns:
-            Truncated Gutenberg-Richter distribution as an instance of the
-            :class: openquake.nrmllib.models
-
-        '''
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def to_hazardlib(self, mag_freq_dist):
-        """
-        Converts the input MFD from the openquake.nrmllib.models format
-        to openquake.hazardlib format
-        """
-        raise NotImplementedError
-
-
-class ConvertTruncGR(MFDConverter):
-    '''
-     Converts the :class: openquake.hazardlib.mfd.truncated_gr to
-     the class openquake.nrmllib.models.TGRMFD
-    '''
-    def convert(self, mag_freq_dist):
-        '''
-        Converts the input truncated Gutenberg-Richter magnitude frequency
-        distribution to the required openquake.nrmlib implementation
-
-        :param mag_freq_dist:
-            Magnitude frequency distribution as either instance of the :class:
-            openquake.hazardlib.mfd.truncated_gr.TruncatedGRMFD
-
-        :returns:
-            Truncated Gutenberg-Richter distribution as an instance of the
-            :class: openquake.nrmllib.models.TGRMFD
-
-        '''
-        assert isinstance(mag_freq_dist, mfd.truncated_gr.TruncatedGRMFD)
-        return models.TGRMFD(a_val=mag_freq_dist.a_val,
-                             b_val=mag_freq_dist.b_val,
-                             min_mag=mag_freq_dist.min_mag,
-                             max_mag=mag_freq_dist.max_mag)
-
-    def to_hazardlib(self, mag_freq_dist):
-        """
-
-        """
-        assert isinstance(mag_freq_dist, models.TGRMFD)
-        return mfd.truncated_gr.TruncatedGRMFD(
-            a_val = mag_freq_dist.a_val,
-            b_val = mag_freq_dist.b_val,
-            min_mag = mag_freq_dist.min_mag,
-            max_mag = mag_freq_dist.max_mag,
-            bin_width=0.1)
-
-
-
-
-class ConvertIncremental(MFDConverter):
-    '''
-     Converts an evenly discretized incremental magnitude frequency
-     distribution in the form of either
-     :class: openquake.hazardlib.mfd.evenly_discretized.EvenlyDiscretized or
-     the :class: openquake.nrmllib.models.IncrementalMFD
-    '''
-    def convert(self, mag_freq_dist):
-        '''
-        :param mag_freq_dist:
-            Magnitude frequency distribution as instance of the :class:
-            openquake.hazardlib.mfd.evenly_discretized.EvenlyDiscretized
-
-        :returns:
-            Evenly discretized magnitude frequency distribution as an instance
-            of the :class: openquake.nrmllib.models.IncrementalMFD
-
-        '''
-        assert isinstance(mag_freq_dist,
-                          mfd.evenly_discretized.EvenlyDiscretizedMFD)
-        return models.IncrementalMFD(
-            min_mag=mag_freq_dist.min_mag,
-            bin_width=mag_freq_dist.bin_width,
-            occur_rates=mag_freq_dist.occurrence_rates)
-
-    def to_hazardlib(self, mag_freq_dist):
-        """
-
-        """
-        assert isinstance(mag_freq_dist, models.IncrementalMFD)
-        return mfd.evenly_discretized.EvenlyDiscretizedMFD(
-            min_mag=mag_freq_dist.min_mag,
-            bin_width=mag_freq_dist.bin_width,
-            occurrence_rates=mag_freq_dist.occur_rates)
-
-
-MFD_MAP = {'TruncatedGRMFD': ConvertTruncGR(),
-           'EvenlyDiscretizedMFD': ConvertIncremental()}
-
-MFD_TOHAZLIB_MAP = {'TGRMFD': ConvertTruncGR(),
-                    'IncrementalMFD': ConvertIncremental()}
-# Accepted MFD name lists
-ACCEPTED_MFD = MFD_TOHAZLIB_MAP.keys()
-
-
-def render_mfd(mag_freq_dist):
-    '''
-    Render the magnitude frequency distribution
-    '''
-
-    mfd_name = mag_freq_dist.__class__.__name__
-    if mfd_name in ACCEPTED_MFD:
-        # Class is already an instance of a oq.nrmllib.models mfd class
-        return mag_freq_dist
-
-    if not mfd_name in MFD_MAP.keys():
-        raise ValueError('Magnitude frequency distribution %s not supported'
-                         % mfd_name)
-    return MFD_MAP[mfd_name].convert(mag_freq_dist)
-
-
-def mfd_to_hazardlib(mag_freq_dist):
-    """
-    Returns the MFD in an openquake.hazardlib supported format
-    """
-    mfd_name = mag_freq_dist.__class__.__name__
-    if isinstance(mag_freq_dist, mfd.base.BaseMFD):
-        # Already a valid OQ hazardlib class
-        return mag_freq_dist
-    elif mfd_name in ACCEPTED_MFD:
-        # Convert from nrmllib class to OQ-hazardlib
-        return MFD_TOHAZLIB_MAP[mfd_name].to_hazardlib(mag_freq_dist)
-    else:
-        raise ValueError('Magnitude frequency distribution %s not supported'
-                         % mfd_name)
 
 
 def render_aspect_ratio(aspect_ratio, use_default=False):
@@ -231,34 +80,6 @@ def render_aspect_ratio(aspect_ratio, use_default=False):
         else:
             raise ValueError('Rupture aspect ratio not defined!')
 
-
-def render_mag_scale_rel(mag_scale_rel, use_default=False):
-    '''
-    Returns the class string of the Magnitude Scaling relation class
-    or returns the string for 'WC1994' otherwise
-
-    :param mag_scale_rel:
-        Instance of the :class: openquake.hazardlib.scalerel.base.Base
-
-    :param bool use_default:
-        Boolean flag to opt to use defaults (True) or not. If set to False
-        then ValueError will be raised if information is missing
-
-    :returns:
-        String code of scaling relation class
-    '''
-    if isinstance(mag_scale_rel, str):
-        return mag_scale_rel
-
-    if mag_scale_rel:
-        return mag_scale_rel.__class__.__name__
-    else:
-        if use_default:
-            # Returns the Wells and Coppersmith string
-            return 'WC1994'
-        else:
-            raise ValueError('Magnitude Scaling Relation Not Defined!')
-
 def mag_scale_rel_to_hazardlib(mag_scale_rel, use_default=False):
     """
     Returns the magnitude scaling relation in a format readable by
@@ -279,54 +100,6 @@ def mag_scale_rel_to_hazardlib(mag_scale_rel, use_default=False):
         else:
             raise ValueError('Magnitude Scaling Relation Not Defined!')
 
-
-def render_npd(nodal_plane_dist, use_default=False):
-    '''
-    Checks to see if nodal plane distribution exists and renders to
-    an instances of the class openquake.nrmllib.models.NodalPlane
-
-    :param nodal_plane_dist:
-        Nodal plane distribution of a source as either an instance of
-        :class: openquake.nrmllib.models.NodalPlane or
-        :class: openquake.hazardlib.pmf.PMF
-
-    :param bool use_default:
-        Boolean flag to opt to use defaults (True) or not. If set to False
-        then ValueError will be raised if information is missing
-
-    :returns:
-        List of instances of openquake.nrmllib.models.NodalPlane
-    '''
-    if isinstance(nodal_plane_dist, list):
-        for npd in nodal_plane_dist:
-            assert isinstance(npd, models.NodalPlane)
-        return nodal_plane_dist
-
-    elif isinstance(nodal_plane_dist, PMF):
-        # Create an instance of openquak.nrmllib.models.NodalPlane
-        prob_sum = Decimal('0.0')
-        output_npd = []
-        for (prob, value) in nodal_plane_dist.data:
-            prob_sum += Decimal(str(prob))
-            if not isinstance(value, NodalPlane):
-                raise ValueError('Nodal Planes incorrectly formatted!')
-
-            output_npd.append(models.NodalPlane(Decimal(str(prob)),
-                                                strike=value.strike,
-                                                dip=value.dip,
-                                                rake=value.rake))
-        if not prob_sum == Decimal('1.0'):
-            raise ValueError('Nodal Plane probabilities do not sum to 1.0')
-
-        return output_npd
-    else:
-        if use_default:
-            # Use a default nodal plane with strike 0, dip 90 and rake 0.
-            return [models.NodalPlane(Decimal('1.0'), strike=0., dip=90.,
-                                      rake=0.)]
-        else:
-            raise ValueError('Nodal Plane distribution not defined')
-
 def npd_to_pmf(nodal_plane_dist, use_default=False):
     """
     Returns the nodal plane distribution as an instance of the PMF class
@@ -334,48 +107,11 @@ def npd_to_pmf(nodal_plane_dist, use_default=False):
     if isinstance(nodal_plane_dist, PMF):
         # Aready in PMF format - return
         return nodal_plane_dist
-    elif isinstance(nodal_plane_dist, list):
-        npd_list = []
-        for npd in nodal_plane_dist:
-            assert isinstance(npd, models.NodalPlane)
-            npd_list.append((npd.probability,
-                             NodalPlane(npd.strike, npd.dip, npd.rake)))
-        return PMF(npd_list)
     else:
         if use_default:
             return PMF([(1.0, NodalPlane(0.0, 90.0, 0.0))])
         else:
             raise ValueError('Nodal Plane distribution not defined')
-
-def render_hdd(hypo_depth_dist, use_default=False):
-    '''
-    Check to see if hypocentral depth distribution exists. If it
-    is already defined as an instance of
-    openquake.nrmllib.HypocentralDepth then returns. If it is an instance
-    of openquake.hazardlib.pmf.PMF then convert to nrmllib version
-    '''
-    if isinstance(hypo_depth_dist, list):
-        for hdd in hypo_depth_dist:
-            assert isinstance(hdd, models.HypocentralDepth)
-
-        return hypo_depth_dist
-    elif isinstance(hypo_depth_dist, PMF):
-        prob_sum = Decimal('0.0')
-        output_hdd = []
-        for (prob, value) in hypo_depth_dist.data:
-            prob_sum += Decimal(str(prob))
-            output_hdd.append(models.HypocentralDepth(prob, value))
-
-        if not prob_sum == Decimal('1.0'):
-            raise ValueError('Hypocentral depth disribution probabilities '
-                             'do not sum to 1.0')
-        return output_hdd
-    else:
-        if use_default:
-            # Default to a single hypocentral depth of 1.0
-            return [models.HypocentralDepth(Decimal('1.0'), 10.)]
-        else:
-            raise ValueError('Hypocentral depth distribution not defined!')
 
 def hdd_to_pmf(hypo_depth_dist, use_default=False):
     """
@@ -385,13 +121,6 @@ def hdd_to_pmf(hypo_depth_dist, use_default=False):
     if isinstance(hypo_depth_dist, PMF):
         # Is already instance of PMF
         return hypo_depth_dist
-    elif isinstance(hypo_depth_dist, list):
-        # Convert from :class: openquake.nrmllib.models.HypocentralDepth
-        hdd_list = []
-        for hdd in hypo_depth_dist:
-            assert isinstance(hdd, models.HypocentralDepth)
-            hdd_list.append((hdd.probability, hdd.depth))
-        return PMF(hdd_list)
     else:
         if use_default:
             # Default value of 10 km accepted
@@ -416,7 +145,6 @@ def simple_trace_to_wkt_linestring(trace):
     trace_str = trace_str.lstrip(' ')
     return 'LINESTRING (' + trace_str.rstrip(',') + ')'
 
-
 def simple_edge_to_wkt_linestring(edge):
     '''
     Coverts a simple fault trace to well-known text format
@@ -433,30 +161,3 @@ def simple_edge_to_wkt_linestring(edge):
                                      point.depth)
     trace_str = trace_str.lstrip(' ')
     return 'LINESTRING (' + trace_str.rstrip(',') + ')'
-
-
-def complex_trace_to_wkt_linestring(edges):
-    '''
-    Converts a set of complex fault edges to an instance of the :class:
-    openquake.nrmllib.models.ComplexFaultGeometry
-
-    :param list edges:
-        Edges of the fault as a list of instances of the :class:
-        openquake.hazardlib.geo.line.Line
-
-    :returns:
-        Complex fault geometry as instance of the :class:
-        openquake.nrmllib.models.ComplexFaultGeometry
-
-    '''
-    int_edges = []
-    for iloc, edge in enumerate(edges):
-        if iloc == 0:
-            top_edge = simple_edge_to_wkt_linestring(edge)
-        elif iloc == len(edges) - 1:
-            bottom_edge = simple_edge_to_wkt_linestring(edge)
-        else:
-            int_edges.append(simple_edge_to_wkt_linestring(edge))
-    if len(int_edges) == 0:
-        int_edges = None
-    return models.ComplexFaultGeometry(top_edge, bottom_edge, int_edges)

--- a/hmtk/sources/source_model.py
+++ b/hmtk/sources/source_model.py
@@ -51,12 +51,15 @@ Module implements :class: hmtk.sources.source_model.mtkSourceModel, the
 general class to describe a set of seismogenic sources
 '''
 
-from openquake.nrmllib import models
-from openquake.nrmllib.hazard.writers import SourceModelXMLWriter
+#from openquake.nrmllib import models
+#from openquake.nrmllib.hazard.writers import SourceModelXMLWriter
+from openquake.hazardlib.tom import PoissonTOM
+from openquake.commonlib.sourcewriter import write_source_model
 from hmtk.sources.point_source import mtkPointSource
 from hmtk.sources.area_source import mtkAreaSource
 from hmtk.sources.simple_fault_source import mtkSimpleFaultSource
 from hmtk.sources.complex_fault_source import mtkComplexFaultSource
+
 
 class mtkSourceModel(object):
     '''
@@ -103,14 +106,12 @@ class mtkSourceModel(object):
             If set to False, ValueErrors will be raised when an essential
             attribute is missing.
         '''
-        output_model = models.SourceModel(name=self.name, sources=[])
-
-        for source in self.sources:
-            output_model.sources.append(
-                source.create_oqnrml_source(use_defaults))
-
-        writer = SourceModelXMLWriter(filename)
-        writer.serialize(output_model)
+        source_model = self.convert_to_oqhazardlib(PoissonTOM(1.0),
+                                                   2.0, # Default values 
+                                                   2.0,
+                                                   10.0,
+                                                   use_defaults=use_defaults)
+        write_source_model(filename, source_model, name=self.name)
 
     def convert_to_oqhazardlib(self, tom, simple_mesh_spacing=1.0,
             complex_mesh_spacing=2.0, area_discretisation=10.0,
@@ -145,5 +146,7 @@ class mtkSourceModel(object):
             else:
                 raise ValueError('Source type not recognised!')
         return oq_source_model
+        
+    
 
 

--- a/tests/parsers/source_models/data/mixed_source_model_nrml4_2.xml
+++ b/tests/parsers/source_models/data/mixed_source_model_nrml4_2.xml
@@ -83,7 +83,7 @@
 
         </areaSource>
 
-        <pointSource id="2" name="point" tectonicRegion="Stable Continental Crust">
+        <pointSource id="3" name="point" tectonicRegion="Stable Continental Crust">
 
             <pointGeometry>
                 <gml:Point>
@@ -111,7 +111,7 @@
 
         </pointSource>
 
-        <simpleFaultSource id="3" name="Mount Diablo Thrust" tectonicRegion="Active Shallow Crust">
+        <simpleFaultSource id="4" name="Mount Diablo Thrust" tectonicRegion="Active Shallow Crust">
 
             <simpleFaultGeometry>
                 <gml:LineString>
@@ -137,7 +137,7 @@
             <rake>30.0</rake>
         </simpleFaultSource>
 
-        <complexFaultSource id="4" name="Cascadia Megathrust" tectonicRegion="Subduction Interface">
+        <complexFaultSource id="5" name="Cascadia Megathrust" tectonicRegion="Subduction Interface">
 
             <complexFaultGeometry>
                 <faultTopEdge>

--- a/tests/parsers/source_models/nrml_04_parser_test.py
+++ b/tests/parsers/source_models/nrml_04_parser_test.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env/python
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#
+# LICENSE
+#
+# Copyright (c) 2015, GEM Foundation
+#
+# The Hazard Modeller's Toolkit is free software: you can redistribute
+# it and/or modify it under the terms of the GNU Affero General Public
+# License as published by the Free Software Foundation, either version
+# 3 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>
+#
+#DISCLAIMER
+#
+# The software Hazard Modeller's Toolkit (hmtk) provided herein
+# is released as a prototype implementation on behalf of
+# scientists and engineers working within the GEM Foundation (Global
+# Earthquake Model).
+#
+# It is distributed for the purpose of open collaboration and in the
+# hope that it will be useful to the scientific, engineering, disaster
+# risk and software design communities.
+#
+# The software is NOT distributed as part of GEM's OpenQuake suite
+# (http://www.globalquakemodel.org/openquake) and must be considered as a
+# separate entity. The software provided herein is designed and implemented
+# by scientific staff. It is not developed to the design standards, nor
+# subject to same level of critical review by professional software
+# developers, as GEM's OpenQuake software suite.
+#
+# Feedback and contribution to the software is welcome, and can be
+# directed to the hazard scientific staff of the GEM Model Facility
+# (hazard@globalquakemodel.org).
+#
+# The Hazard Modeller's Toolkit (hmtk) is therefore distributed WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
+#
+# The GEM Foundation, and the authors of the software, assume no
+# liability for use of the software.
+"""
+Test suite for the NRML Source Model parser
+"""
+import os
+import unittest
+import numpy as np
+from openquake.commonlib.node import node_from_xml
+from openquake.hazardlib.geo.point import Point
+from openquake.hazardlib.geo.line import Line
+from openquake.hazardlib.geo.polygon import Polygon
+from openquake.hazardlib.scalerel import get_available_scalerel
+from openquake.hazardlib.scalerel.wc1994 import WC1994
+from openquake.hazardlib import mfd
+from openquake.hazardlib.pmf import PMF
+from openquake.hazardlib.geo.nodalplane import NodalPlane
+from hmtk.sources.source_model import mtkSourceModel
+from hmtk.sources.point_source import mtkPointSource
+from hmtk.sources.area_source import mtkAreaSource
+from hmtk.sources.simple_fault_source import mtkSimpleFaultSource
+from hmtk.sources.complex_fault_source import mtkComplexFaultSource
+from hmtk.parsers.source_model.nrml04_parser import nrmlSourceModelParser
+
+BASE_PATH = os.path.join(os.path.dirname(__file__), "data")
+
+class NRMLParserFullModelTestCase(unittest.TestCase):
+    """
+    Tests the NRML parser for the case in which a full and validated NRML
+    source model is input
+    """
+    def setUp(self):
+        self.nrml_file = os.path.join(BASE_PATH,
+                                      "mixed_source_model_nrml4_2.xml")
+    
+    def test_execution_full(self):
+        """
+        Tests the execution of the reader for the full model
+        """
+        parser = nrmlSourceModelParser(self.nrml_file)
+        model = parser.read_file("XXX")
+        # Basic tests
+        self.assertEqual(model.id, "XXX")
+        self.assertEqual(model.name, "Some Source Model")
+        self.assertEqual(len(model.sources), 5)
+        # Area Source
+        self._check_area_source(model.sources[0])
+        self._check_point_source(model.sources[2])
+        self._check_simple_fault_source(model.sources[3])
+        self._check_complex_fault_source(model.sources[4])
+    
+    def _check_area_source(self, source):
+        self.assertTrue(isinstance(source, mtkAreaSource))
+        self.assertEqual(source.id, "1")
+        self.assertEqual(source.name, "Quito")
+        self.assertEqual(source.geometry.wkt,
+            'POLYGON((-122.5 38.0, -122.0 38.5, -121.5 38.0, '
+            '-122.0 37.5, -122.5 38.0))')
+        self.assertAlmostEqual(source.upper_depth, 0.0)
+        self.assertAlmostEqual(source.lower_depth, 10.0)
+        self.assertAlmostEqual(source.rupt_aspect_ratio, 1.5)
+        for iloc, (prob, npd) in enumerate(source.nodal_plane_dist.data):
+            if iloc == 0:
+                self.assertAlmostEqual(prob, 0.3),
+                self.assertAlmostEqual(npd.strike, 0.0)
+                self.assertAlmostEqual(npd.dip, 90.0)
+                self.assertAlmostEqual(npd.rake, 0.0)
+            else:
+                self.assertAlmostEqual(prob, 0.7),
+                self.assertAlmostEqual(npd.strike, 90.0)
+                self.assertAlmostEqual(npd.dip, 45.0)
+                self.assertAlmostEqual(npd.rake, 90.0)
+            
+        for iloc, (prob, hdd) in enumerate(source.hypo_depth_dist.data):
+            if iloc == 0:
+                self.assertAlmostEqual(prob, 0.5)
+                self.assertAlmostEqual(hdd, 4.0)
+            else:
+                self.assertAlmostEqual(prob, 0.5)
+                self.assertAlmostEqual(hdd, 8.0)
+        self.assertTrue(isinstance(source.mfd, mfd.EvenlyDiscretizedMFD))
+
+    def _check_point_source(self, source):
+        self.assertTrue(isinstance(source, mtkPointSource))
+        self.assertEqual(source.id, "3")
+        self.assertEqual(source.name, "point")
+        self.assertAlmostEqual(source.geometry.x, -122.0)
+        self.assertAlmostEqual(source.geometry.y, 38.0)
+        self.assertAlmostEqual(source.upper_depth, 0.0)
+        self.assertAlmostEqual(source.lower_depth, 10.0)
+        self.assertAlmostEqual(source.rupt_aspect_ratio, 0.5)
+        self.assertTrue(isinstance(source.mfd, mfd.TruncatedGRMFD))
+        self.assertAlmostEqual(source.mfd.a_val, -3.5)
+        self.assertAlmostEqual(source.mfd.b_val, 1.0)
+        self.assertAlmostEqual(source.mfd.min_mag, 5.0)
+        self.assertAlmostEqual(source.mfd.max_mag, 6.5)
+        for iloc, (prob, npd) in enumerate(source.nodal_plane_dist.data):
+            if iloc == 0:
+                self.assertAlmostEqual(prob, 0.3),
+                self.assertAlmostEqual(npd.strike, 0.0)
+                self.assertAlmostEqual(npd.dip, 90.0)
+                self.assertAlmostEqual(npd.rake, 0.0)
+            else:
+                self.assertAlmostEqual(prob, 0.7),
+                self.assertAlmostEqual(npd.strike, 90.0)
+                self.assertAlmostEqual(npd.dip, 45.0)
+                self.assertAlmostEqual(npd.rake, 90.0)
+            
+        for iloc, (prob, hdd) in enumerate(source.hypo_depth_dist.data):
+            if iloc == 0:
+                self.assertAlmostEqual(prob, 0.5)
+                self.assertAlmostEqual(hdd, 4.0)
+            else:
+                self.assertAlmostEqual(prob, 0.5)
+                self.assertAlmostEqual(hdd, 8.0)
+    
+    def _check_simple_fault_source(self, source):
+        self.assertTrue(isinstance(source, mtkSimpleFaultSource))
+        self.assertEqual(source.id, "4")
+        self.assertEqual(source.name, "Mount Diablo Thrust")
+        self.assertTrue(isinstance(source.mag_scale_rel, WC1994))
+        self.assertAlmostEqual(source.rake, 30.0)
+        self.assertAlmostEqual(source.rupt_aspect_ratio, 1.5)
+        self.assertAlmostEqual(source.dip, 45.0)
+        self.assertAlmostEqual(source.upper_depth, 10.0)
+        self.assertAlmostEqual(source.lower_depth, 20.0)
+        self.assertEqual(str(source.fault_trace.points[0]),
+            "<Latitude=37.730100, Longitude=-121.822900, Depth=0.0000>")
+        self.assertEqual(str(source.fault_trace.points[1]),
+            "<Latitude=37.877100, Longitude=-122.038800, Depth=0.0000>")
+    
+    def _check_complex_fault_source(self, source):
+        self.assertTrue(isinstance(source, mtkComplexFaultSource))
+        self.assertEqual(source.id, "5")
+        self.assertEqual(source.name, "Cascadia Megathrust")
+        self.assertTrue(isinstance(source.mag_scale_rel, WC1994))
+        self.assertAlmostEqual(source.rake, 30.0)
+        self.assertAlmostEqual(source.rupt_aspect_ratio, 2.0)
+        self.assertAlmostEqual(source.dip, 10.4179999)
+        self.assertAlmostEqual(source.upper_depth, 4.89734)
+
+
+class NRMLParserPartialModelTestCase(unittest.TestCase):
+    """
+    Tests the NRML parser for the case in which a full and validated NRML
+    source model is input
+    """
+    def setUp(self):
+        self.nrml_file = os.path.join(BASE_PATH,
+                                      "mixed_source_model_nrml4_2_minimum.xml")
+
+    def test_execution_full(self):
+        """
+        Tests the execution of the reader for the full model
+        """
+        parser = nrmlSourceModelParser(self.nrml_file)
+        model = parser.read_file("XXX")
+        # Basic tests
+        self.assertEqual(model.id, "XXX")
+        self.assertEqual(model.name, "Some Source Model")
+        self.assertEqual(len(model.sources), 4)
+        # Area Source
+        self._check_area_source(model.sources[0])
+        self._check_point_source(model.sources[1])
+        self._check_simple_fault_source(model.sources[2])
+        self._check_complex_fault_source(model.sources[3])
+
+    def _check_area_source(self, source):
+        self.assertTrue(isinstance(source, mtkAreaSource))
+        self.assertEqual(source.id, "1")
+        self.assertEqual(source.name, "Quito")
+        self.assertEqual(source.geometry.wkt,
+            'POLYGON((-122.5 38.0, -122.0 38.5, -121.5 38.0, '
+            '-122.0 37.5, -122.5 38.0))')
+        self.assertAlmostEqual(source.upper_depth, 0.0)
+        self.assertAlmostEqual(source.lower_depth, 10.0)
+        self.assertFalse(source.rupt_aspect_ratio)
+        self.assertFalse(source.mag_scale_rel)
+        self.assertFalse(source.mfd)
+        self.assertFalse(source.nodal_plane_dist)
+        self.assertFalse(source.hypo_depth_dist)
+        
+    def _check_point_source(self, source):
+        self.assertTrue(isinstance(source, mtkPointSource))
+        self.assertEqual(source.id, "2")
+        self.assertEqual(source.name, "point")
+        self.assertAlmostEqual(source.geometry.x, -122.0)
+        self.assertAlmostEqual(source.geometry.y, 38.0)
+        self.assertAlmostEqual(source.upper_depth, 0.0)
+        self.assertAlmostEqual(source.lower_depth, 10.0)
+        self.assertFalse(source.rupt_aspect_ratio)
+        self.assertFalse(source.mag_scale_rel)
+        self.assertFalse(source.mfd)
+        self.assertFalse(source.nodal_plane_dist)
+        self.assertFalse(source.hypo_depth_dist)
+
+    
+    def _check_simple_fault_source(self, source):
+        self.assertTrue(isinstance(source, mtkSimpleFaultSource))
+        self.assertEqual(source.id, "3")
+        self.assertEqual(source.name, "Mount Diablo Thrust")
+        self.assertAlmostEqual(source.dip, 45.0)
+        self.assertAlmostEqual(source.upper_depth, 10.0)
+        self.assertAlmostEqual(source.lower_depth, 20.0)
+        self.assertEqual(str(source.fault_trace.points[0]),
+            "<Latitude=37.730100, Longitude=-121.822900, Depth=0.0000>")
+        self.assertEqual(str(source.fault_trace.points[1]),
+            "<Latitude=37.877100, Longitude=-122.038800, Depth=0.0000>")
+        self.assertFalse(source.rupt_aspect_ratio)
+        self.assertFalse(source.mag_scale_rel)
+        self.assertFalse(source.mfd)
+    
+    def _check_complex_fault_source(self, source):
+        self.assertTrue(isinstance(source, mtkComplexFaultSource))
+        self.assertEqual(source.id, "4")
+        self.assertEqual(source.name, "Cascadia Megathrust")
+        self.assertAlmostEqual(source.dip, 10.4179999)
+        self.assertAlmostEqual(source.upper_depth, 4.89734)
+        self.assertFalse(source.rupt_aspect_ratio)
+        self.assertFalse(source.mag_scale_rel)
+        self.assertFalse(source.mfd)
+
+    
+    
+    

--- a/tests/sources/test_area_source.py
+++ b/tests/sources/test_area_source.py
@@ -55,7 +55,7 @@ hmtk.sources.area_source.mtkAreaSource
 import unittest
 import warnings
 import numpy as np
-from openquake.nrmllib import models
+#from openquake.nrmllib import models
 from openquake.hazardlib.geo import point, polygon
 from openquake.hazardlib.source.area import AreaSource
 from openquake.hazardlib.pmf import PMF
@@ -226,43 +226,43 @@ class TestAreaSource(unittest.TestCase):
             self.assertEqual(ver.exception.message,
                              'No events found in catalogue!')
 
-    def test_create_oqnmrl_area_source(self):
-        '''
-        Tests the conversion of a point source to an instance of the :class:
-        oqnrmllib.models.AreaSource
-        '''
-        # Define a complete source
-        area_geom = polygon.Polygon([point.Point(10., 10.),
-                                     point.Point(12., 10.),
-                                     point.Point(12., 8.),
-                                     point.Point(10., 8.)])
-        self.area_source = mtkAreaSource('001',
-            'A Point Source',
-            trt='Active Shallow Crust',
-            geometry = area_geom,
-            upper_depth = 0.,
-            lower_depth = 20.,
-            mag_scale_rel=None,
-            rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
-            nodal_plane_dist=None,
-            hypo_depth_dist=None)
+    #~ def test_create_oqnmrl_area_source(self):
+        #~ '''
+        #~ Tests the conversion of a point source to an instance of the :class:
+        #~ oqnrmllib.models.AreaSource
+        #~ '''
+        #~ # Define a complete source
+        #~ area_geom = polygon.Polygon([point.Point(10., 10.),
+                                     #~ point.Point(12., 10.),
+                                     #~ point.Point(12., 8.),
+                                     #~ point.Point(10., 8.)])
+        #~ self.area_source = mtkAreaSource('001',
+            #~ 'A Point Source',
+            #~ trt='Active Shallow Crust',
+            #~ geometry = area_geom,
+            #~ upper_depth = 0.,
+            #~ lower_depth = 20.,
+            #~ mag_scale_rel=None,
+            #~ rupt_aspect_ratio=1.0,
+            #~ mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            #~ nodal_plane_dist=None,
+            #~ hypo_depth_dist=None)
 
-        expected_source = models.AreaSource(
-            '001',
-            'A Point Source',
-            geometry=models.AreaGeometry(area_geom.wkt, 0., 20.),
-            mag_scale_rel='WC1994',
-            rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
-            nodal_plane_dist=None,
-            hypo_depth_dist=None)
-        test_source = self.area_source.create_oqnrml_source(use_defaults=True)
-        self.assertTrue(isinstance(test_source, models.AreaSource))
-        self.assertEqual(test_source.id, expected_source.id)
-        self.assertEqual(test_source.name, expected_source.name)
-        self.assertAlmostEqual(test_source.mfd.b_val,
-                               expected_source.mfd.b_val)
+        #~ expected_source = models.AreaSource(
+            #~ '001',
+            #~ 'A Point Source',
+            #~ geometry=models.AreaGeometry(area_geom.wkt, 0., 20.),
+            #~ mag_scale_rel='WC1994',
+            #~ rupt_aspect_ratio=1.0,
+            #~ mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            #~ nodal_plane_dist=None,
+            #~ hypo_depth_dist=None)
+        #~ test_source = self.area_source.create_oqnrml_source(use_defaults=True)
+        #~ self.assertTrue(isinstance(test_source, models.AreaSource))
+        #~ self.assertEqual(test_source.id, expected_source.id)
+        #~ self.assertEqual(test_source.name, expected_source.name)
+        #~ self.assertAlmostEqual(test_source.mfd.b_val,
+                               #~ expected_source.mfd.b_val)
 
     def test_create_oqhazardlib_source(self):
         """
@@ -272,6 +272,7 @@ class TestAreaSource(unittest.TestCase):
                                      point.Point(12., 10.),
                                      point.Point(12., 8.),
                                      point.Point(10., 8.)])
+        mfd1 = TruncatedGRMFD(5.0, 8.0, 0.1, 3.0, 1.0)
         self.area_source = mtkAreaSource('001',
             'A Point Source',
             trt='Active Shallow Crust',
@@ -280,7 +281,7 @@ class TestAreaSource(unittest.TestCase):
             lower_depth = 20.,
             mag_scale_rel=None,
             rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            mfd=mfd1,
             nodal_plane_dist=None,
             hypo_depth_dist=None)
         test_source = self.area_source.create_oqhazardlib_source(TOM, 1.0,

--- a/tests/sources/test_complex_fault_source.py
+++ b/tests/sources/test_complex_fault_source.py
@@ -55,7 +55,7 @@ hmtk.sources.complex_fault_source.mtkComplexFaultSource
 import unittest
 import warnings
 import numpy as np
-from openquake.nrmllib import models
+#from openquake.nrmllib import models
 from openquake.hazardlib.geo import point, line
 from openquake.hazardlib.geo.surface.complex_fault import ComplexFaultSurface
 from openquake.hazardlib.tom import PoissonTOM
@@ -209,45 +209,45 @@ class TestComplexFaultSource(unittest.TestCase):
         self.assertEqual(ver.exception.message,
                          'No events found in catalogue!')
 
-    def test_create_oqnmrl_complex_fault_source(self):
-        '''
-        Tests the conversion of a point source to an instance of the :class:
-        oqnrmllib.models.AreaSource
-        '''
-        complex_edges = [
-            line.Line([point.Point(11., 10., 0.), point.Point(10., 10., 0.)]),
-            line.Line([point.Point(11.5, 10., 21.), point.Point(10.0, 10., 21.)])
-            ]
-        self.fault_source = mtkComplexFaultSource('001',
-            'A Fault Source',
-            trt='Active Shallow Crust',
-            geometry = None,
-            mag_scale_rel=None,
-            rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
-            rake=0.)
-        self.fault_source.create_geometry(complex_edges, 2.0)
+    #~ def test_create_oqnmrl_complex_fault_source(self):
+        #~ '''
+        #~ Tests the conversion of a point source to an instance of the :class:
+        #~ oqnrmllib.models.AreaSource
+        #~ '''
+        #~ complex_edges = [
+            #~ line.Line([point.Point(11., 10., 0.), point.Point(10., 10., 0.)]),
+            #~ line.Line([point.Point(11.5, 10., 21.), point.Point(10.0, 10., 21.)])
+            #~ ]
+        #~ self.fault_source = mtkComplexFaultSource('001',
+            #~ 'A Fault Source',
+            #~ trt='Active Shallow Crust',
+            #~ geometry = None,
+            #~ mag_scale_rel=None,
+            #~ rupt_aspect_ratio=1.0,
+            #~ mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            #~ rake=0.)
+        #~ self.fault_source.create_geometry(complex_edges, 2.0)
 
-        expected_geometry=models.ComplexFaultGeometry(
-            top_edge_wkt='LINESTRING (10.0 10.0 0.0, 11.0 10.0 0.0)',
-            bottom_edge_wkt='LINESTRING (10.0 10.0 20.0, 11.5 10.0 21.0)')
+        #~ expected_geometry=models.ComplexFaultGeometry(
+            #~ top_edge_wkt='LINESTRING (10.0 10.0 0.0, 11.0 10.0 0.0)',
+            #~ bottom_edge_wkt='LINESTRING (10.0 10.0 20.0, 11.5 10.0 21.0)')
 
-        expected_source = models.ComplexFaultSource(
-            '001',
-            'A Fault Source',
-            trt='Active Shallow Crust',
-            geometry=expected_geometry,
-            mag_scale_rel='WC1994',
-            rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
-            rake=90.)
+        #~ expected_source = models.ComplexFaultSource(
+            #~ '001',
+            #~ 'A Fault Source',
+            #~ trt='Active Shallow Crust',
+            #~ geometry=expected_geometry,
+            #~ mag_scale_rel='WC1994',
+            #~ rupt_aspect_ratio=1.0,
+            #~ mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            #~ rake=90.)
 
-        test_source = self.fault_source.create_oqnrml_source(use_defaults=True)
-        self.assertTrue(isinstance(test_source, models.ComplexFaultSource))
-        self.assertEqual(test_source.id, expected_source.id)
-        self.assertEqual(test_source.name, expected_source.name)
-        self.assertAlmostEqual(test_source.mfd.b_val,
-                               expected_source.mfd.b_val)
+        #~ test_source = self.fault_source.create_oqnrml_source(use_defaults=True)
+        #~ self.assertTrue(isinstance(test_source, models.ComplexFaultSource))
+        #~ self.assertEqual(test_source.id, expected_source.id)
+        #~ self.assertEqual(test_source.name, expected_source.name)
+        #~ self.assertAlmostEqual(test_source.mfd.b_val,
+                               #~ expected_source.mfd.b_val)
 
 
 
@@ -260,13 +260,14 @@ class TestComplexFaultSource(unittest.TestCase):
             line.Line([point.Point(11., 10., 0.), point.Point(10., 10., 0.)]),
             line.Line([point.Point(11.5, 10., 21.), point.Point(10.0, 10., 21.)])
             ]
+        mfd1 = TruncatedGRMFD(5.0, 8.0, 0.1, 3.0, 1.0)
         self.fault_source = mtkComplexFaultSource('001',
             'A Fault Source',
             trt='Active Shallow Crust',
             geometry = None,
             mag_scale_rel=None,
             rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            mfd=mfd1,
             rake=0.)
         self.fault_source.create_geometry(complex_edges, 2.0)
         test_source = self.fault_source.create_oqhazardlib_source(TOM,

--- a/tests/sources/test_point_source.py
+++ b/tests/sources/test_point_source.py
@@ -56,7 +56,7 @@ import unittest
 import warnings
 import numpy as np
 from copy import deepcopy
-from openquake.nrmllib import models
+#from openquake.nrmllib import models
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.source.point import PointSource
 from openquake.hazardlib.tom import PoissonTOM
@@ -292,46 +292,47 @@ class TestPointSource(unittest.TestCase):
                          'Unrecognised selection type for point source!')
 
 
-    def test_create_oqnmrl_point_source(self):
-        '''
-        Tests the conversion of a point source to an instance of the :class:
-        oqnrmllib.models.PointSource
-        '''
-        # Define a complete source
-        self.point_source = mtkPointSource('001',
-            'A Point Source',
-            trt='Active Shallow Crust',
-            geometry = Point(10., 10.),
-            upper_depth = 0.,
-            lower_depth = 20.,
-            mag_scale_rel=None,
-            rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
-            nodal_plane_dist=None,
-            hypo_depth_dist=None)
+    #~ def test_create_oqnmrl_point_source(self):
+        #~ '''
+        #~ Tests the conversion of a point source to an instance of the :class:
+        #~ oqnrmllib.models.PointSource
+        #~ '''
+        #~ # Define a complete source
+        #~ self.point_source = mtkPointSource('001',
+            #~ 'A Point Source',
+            #~ trt='Active Shallow Crust',
+            #~ geometry = Point(10., 10.),
+            #~ upper_depth = 0.,
+            #~ lower_depth = 20.,
+            #~ mag_scale_rel=None,
+            #~ rupt_aspect_ratio=1.0,
+            #~ mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            #~ nodal_plane_dist=None,
+            #~ hypo_depth_dist=None)
 
-        expected_source = models.PointSource(
-            '001',
-            'A Point Source',
-            geometry=models.PointGeometry('POINT(10.0 10.0)', 0., 20.),
-            mag_scale_rel='WC1994',
-            rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
-            nodal_plane_dist=None,
-            hypo_depth_dist=None)
-        test_source = self.point_source.create_oqnrml_source(use_defaults=True)
-        self.assertTrue(isinstance(test_source, models.PointSource))
-        self.assertEqual(test_source.id, expected_source.id)
-        self.assertEqual(test_source.name, expected_source.name)
-        self.assertDictEqual(test_source.geometry.__dict__,
-                             expected_source.geometry.__dict__)
-        self.assertAlmostEqual(test_source.mfd.b_val,
-                               expected_source.mfd.b_val)
+        #~ expected_source = models.PointSource(
+            #~ '001',
+            #~ 'A Point Source',
+            #~ geometry=models.PointGeometry('POINT(10.0 10.0)', 0., 20.),
+            #~ mag_scale_rel='WC1994',
+            #~ rupt_aspect_ratio=1.0,
+            #~ mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            #~ nodal_plane_dist=None,
+            #~ hypo_depth_dist=None)
+        #~ test_source = self.point_source.create_oqnrml_source(use_defaults=True)
+        #~ self.assertTrue(isinstance(test_source, models.PointSource))
+        #~ self.assertEqual(test_source.id, expected_source.id)
+        #~ self.assertEqual(test_source.name, expected_source.name)
+        #~ self.assertDictEqual(test_source.geometry.__dict__,
+                             #~ expected_source.geometry.__dict__)
+        #~ self.assertAlmostEqual(test_source.mfd.b_val,
+                               #~ expected_source.mfd.b_val)
 
     def test_create_oq_hazardlib_point_source(self):
         """
         Tests the function to create a point source model
         """
+        mfd1 = TruncatedGRMFD(5.0, 8.0, 0.1, 3.0, 1.0)
         self.point_source = mtkPointSource('001',
             'A Point Source',
             trt='Active Shallow Crust',
@@ -340,7 +341,7 @@ class TestPointSource(unittest.TestCase):
             lower_depth = 20.,
             mag_scale_rel=None,
             rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            mfd=mfd1,
             nodal_plane_dist=None,
             hypo_depth_dist=None)
         test_source = self.point_source.create_oqhazardlib_source(TOM,

--- a/tests/sources/test_simple_fault_source.py
+++ b/tests/sources/test_simple_fault_source.py
@@ -55,7 +55,7 @@ hmtk.sources.simple_fault_source.mtkSimpleFaultSource
 import unittest
 import warnings
 import numpy as np
-from openquake.nrmllib import models
+#from openquake.nrmllib import models
 from openquake.hazardlib.geo import point, line
 from openquake.hazardlib.geo.surface.simple_fault import SimpleFaultSurface
 from openquake.hazardlib.source.simple_fault import SimpleFaultSource
@@ -236,56 +236,57 @@ class TestSimpleFaultSource(unittest.TestCase):
         self.assertEqual(ver.exception.message,
                          'No events found in catalogue!')
 
-    def test_create_oqnmrl_simple_fault_source(self):
-        '''
-        Tests the conversion of a point source to an instance of the :class:
-        oqnrmllib.models.SimpleFaultSource
-        '''
-        trace = line.Line([point.Point(10., 10.), point.Point(11., 10.)])
-        #sflt_geom = SimpleFaultSurface.from_fault_data(trace, 0., 20., 90., 1.)
+    #~ def test_create_oqnmrl_simple_fault_source(self):
+        #~ '''
+        #~ Tests the conversion of a point source to an instance of the :class:
+        #~ oqnrmllib.models.SimpleFaultSource
+        #~ '''
+        #~ trace = line.Line([point.Point(10., 10.), point.Point(11., 10.)])
+        #~ #sflt_geom = SimpleFaultSurface.from_fault_data(trace, 0., 20., 90., 1.)
 
-        # Define a complete source
-        self.fault_source = mtkSimpleFaultSource('001',
-            'A Fault Source',
-            trt='Active Shallow Crust',
-            geometry = None,
-            dip = 90.,
-            upper_depth = 0.,
-            lower_depth = 20.,
-            mag_scale_rel=None,
-            rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
-            rake=0.)
-        self.fault_source.create_geometry(trace, 90., 0., 20., 1.0)
+        #~ # Define a complete source
+        #~ self.fault_source = mtkSimpleFaultSource('001',
+            #~ 'A Fault Source',
+            #~ trt='Active Shallow Crust',
+            #~ geometry = None,
+            #~ dip = 90.,
+            #~ upper_depth = 0.,
+            #~ lower_depth = 20.,
+            #~ mag_scale_rel=None,
+            #~ rupt_aspect_ratio=1.0,
+            #~ mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            #~ rake=0.)
+        #~ self.fault_source.create_geometry(trace, 90., 0., 20., 1.0)
 
-        expected_geometry = models.SimpleFaultGeometry(
-            wkt='LINESTRING (10.0 10.0, 11.0 10.0)',
-            dip=90.,
-            upper_seismo_depth=0.,
-            lower_seismo_depth=20.)
-        expected_source = models.SimpleFaultSource(
-            '001',
-            'A Fault Source',
-            trt='Active Shallow Crust',
-            geometry=expected_geometry,
-            mag_scale_rel='WC1994',
-            rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
-            rake=0.)
-        test_source = self.fault_source.create_oqnrml_source(use_defaults=True)
-        self.assertTrue(isinstance(test_source, models.SimpleFaultSource))
-        self.assertEqual(test_source.id, expected_source.id)
-        self.assertEqual(test_source.name, expected_source.name)
-        self.assertDictEqual(test_source.geometry.__dict__,
-                             expected_source.geometry.__dict__)
-        self.assertAlmostEqual(test_source.mfd.b_val,
-                               expected_source.mfd.b_val)
+        #~ expected_geometry = models.SimpleFaultGeometry(
+            #~ wkt='LINESTRING (10.0 10.0, 11.0 10.0)',
+            #~ dip=90.,
+            #~ upper_seismo_depth=0.,
+            #~ lower_seismo_depth=20.)
+        #~ expected_source = models.SimpleFaultSource(
+            #~ '001',
+            #~ 'A Fault Source',
+            #~ trt='Active Shallow Crust',
+            #~ geometry=expected_geometry,
+            #~ mag_scale_rel='WC1994',
+            #~ rupt_aspect_ratio=1.0,
+            #~ mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            #~ rake=0.)
+        #~ test_source = self.fault_source.create_oqnrml_source(use_defaults=True)
+        #~ self.assertTrue(isinstance(test_source, models.SimpleFaultSource))
+        #~ self.assertEqual(test_source.id, expected_source.id)
+        #~ self.assertEqual(test_source.name, expected_source.name)
+        #~ self.assertDictEqual(test_source.geometry.__dict__,
+                             #~ expected_source.geometry.__dict__)
+        #~ self.assertAlmostEqual(test_source.mfd.b_val,
+                               #~ expected_source.mfd.b_val)
 
     def test_create_oqhazardlib_source(self):
         """
         Tests to ensure the hazardlib source is created
         """
         trace = line.Line([point.Point(10., 10.), point.Point(11., 10.)])
+        mfd1 = TruncatedGRMFD(5.0, 8.0, 0.1, 3.0, 1.0)
         self.fault_source = mtkSimpleFaultSource('001',
             'A Fault Source',
             trt='Active Shallow Crust',
@@ -295,7 +296,7 @@ class TestSimpleFaultSource(unittest.TestCase):
             lower_depth = 20.,
             mag_scale_rel=None,
             rupt_aspect_ratio=1.0,
-            mfd=models.TGRMFD(a_val=3., b_val=1.0, min_mag=5.0, max_mag=8.0),
+            mfd=mfd1,
             rake=0.)
         self.fault_source.create_geometry(trace, 90., 0., 20., 1.0)
         test_source = self.fault_source.create_oqhazardlib_source(TOM,

--- a/tests/sources/test_source_conversion_utils.py
+++ b/tests/sources/test_source_conversion_utils.py
@@ -52,7 +52,6 @@ Tests the methods of the module hmtk.sources.source_conversion_utils
 
 import unittest
 import numpy as np
-from openquake.nrmllib import models
 from openquake.hazardlib.pmf import PMF
 from openquake.hazardlib import mfd
 from openquake.hazardlib.scalerel.wc1994 import WC1994
@@ -60,146 +59,6 @@ from openquake.hazardlib.geo.line import Line
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo.nodalplane import NodalPlane
 from hmtk.sources import source_conversion_utils as conv
-
-class TestMFDConverters(unittest.TestCase):
-    '''
-    Tests the magnitude frequency conversion utils functions
-    :class: hmtk.sources.source_conversion_utils.ConvertTruncGR and
-    :class: hmtk.sources.source_conversion_utils.ConvertIncremental
-    '''
-
-    def setUp(self):
-        '''
-        '''
-        self.model = None
-        self.model_gr = mfd.truncated_gr.TruncatedGRMFD(
-            min_mag=5.0,
-            max_mag=8.0,
-            bin_width=0.1,
-            a_val=4.0,
-            b_val=1.0)
-
-        self.model_ed = mfd.evenly_discretized.EvenlyDiscretizedMFD(
-            min_mag=5.0,
-            bin_width=0.1,
-            occurrence_rates=[1., 1., 1., 1., 1.])
-
-    def test_truncgr(self):
-        '''
-        Tests the truncated Gutenberg Richter class
-        '''
-        expected = {'a_val': 4.0, 'b_val': 1.0, 'min_mag': 5.0, 'max_mag': 8.0}
-        self.model = conv.ConvertTruncGR()
-        output = self.model.convert(self.model_gr)
-        for key in expected.keys():
-            self.assertAlmostEqual(expected[key], output.__dict__[key])
-
-    def test_incrementalmfd(self):
-        '''
-        Tests the evenly discretized MFD class
-        '''
-        expected = {'min_mag': 5.0, 'bin_width': 0.1,
-                    'occur_rates': np.ones(5, dtype=float)}
-        self.model = conv.ConvertIncremental()
-        output = self.model.convert(self.model_ed)
-        self.assertAlmostEqual(output.__dict__['min_mag'], 5.0)
-        self.assertAlmostEqual(output.__dict__['bin_width'], 0.1)
-        np.testing.assert_array_almost_equal(
-            output.__dict__['occur_rates'], np.ones(5, dtype=float))
-
-    def test_render_mfd_truncgr(self):
-        '''
-        Tests the function to render the mfd given a valid :class:
-        openquake.hazardlib.mfd.truncated_gr.TruncGRMFD
-        '''
-        expected = {'a_val': 4.0, 'b_val': 1.0, 'min_mag': 5.0, 'max_mag': 8.0}
-        output = conv.render_mfd(self.model_gr)
-        for key in expected.keys():
-            self.assertAlmostEqual(expected[key], output.__dict__[key])
-
-    def test_render_mfd_evenly_discrtized(self):
-        '''
-        Tests the function to render the mfd given a valid :class:
-        openquake.hazardlib.mfd.evenly_discretized.EvenlyDiscretizedMFD
-        '''
-        expected = {'min_mag': 5.0, 'bin_width': 0.1,
-                    'occur_rates': np.ones(5, dtype=float)}
-        output = conv.render_mfd(self.model_ed)
-        self.assertAlmostEqual(output.__dict__['min_mag'], 5.0)
-        self.assertAlmostEqual(output.__dict__['bin_width'], 0.1)
-        np.testing.assert_array_almost_equal(
-            output.__dict__['occur_rates'], np.ones(5, dtype=float))
-
-    def test_raise_error_unrecognised_mfd(self):
-        '''
-        Tests that the render_mfd function raises an error when
-        rendering an unsupported MFD
-        '''
-        class BadInput(object):
-            def __init__(self):
-                return
-
-        with self.assertRaises(ValueError) as ae:
-            _ = conv.render_mfd(BadInput())
-            self.assertEqual(ae.exception.message,
-                             'Magnitude frequency distribution BadInput not '
-                             'supported')
-
-    def test_mfd_to_hazardlib_oq_hazardlib_tgr(self):
-        """
-        Tests that the conversion to hazardlib formulation for the TGRMFD case
-        """
-        output = conv.mfd_to_hazardlib(self.model_gr)
-        self.assertIsInstance(output, mfd.truncated_gr.TruncatedGRMFD)
-        self.assertAlmostEqual(output.b_val, self.model_gr.b_val)
-        self.assertAlmostEqual(output.bin_width, self.model_gr.bin_width)
-
-    def test_mfd_to_hazardlib_nrmllib_tgr(self):
-        """
-        Tests the conversion to hazardlib fomrulation for the 
-        models.TGRMFD case
-        """
-        output = conv.mfd_to_hazardlib(models.TGRMFD(3.0, 1.0, 4.5, 6.5))
-        self.assertIsInstance(output, mfd.truncated_gr.TruncatedGRMFD)
-        self.assertAlmostEqual(output.b_val, 1.0)
-        self.assertAlmostEqual(output.bin_width, 0.1)
-
-    def test_mfd_to_hazardlib_oq_hazardlib_ed(self):
-        """
-        Tests that the conversion to hazardlib formulation for the
-        EvenlyDiscretizedMFD case
-        """
-        output = conv.mfd_to_hazardlib(self.model_ed)
-        self.assertIsInstance(output,
-                              mfd.evenly_discretized.EvenlyDiscretizedMFD)
-        self.assertAlmostEqual(output.min_mag, self.model_gr.min_mag)
-        self.assertAlmostEqual(output.bin_width, self.model_gr.bin_width)
-
-    def test_mfd_to_hazardlib_nrmllib_ed(self):
-        """
-        Tests the conversion to hazardlib fomrulation for the 
-        models.IncrementalMFD case
-        """
-        output = conv.mfd_to_hazardlib(models.IncrementalMFD(4.5, 0.1, [6.5]))
-        self.assertIsInstance(output,
-                              mfd.evenly_discretized.EvenlyDiscretizedMFD)
-        self.assertAlmostEqual(output.min_mag, 4.5)
-        self.assertAlmostEqual(output.bin_width, 0.1)
-
-    def test_mfd_to_hazardlib_unsupported_class(self):
-        """
-        Tests the conversion to the hazardlib using an unsupported class
-        """
-        class BadInput(object):
-            def __init__(self):
-                return
-
-        with self.assertRaises(ValueError) as ae:
-            _ = conv.render_mfd(BadInput())
-            self.assertEqual(ae.exception.message,
-                             'Magnitude frequency distribution BadInput not '
-                             'supported')
-
 
 class TestRenderAspectRatio(unittest.TestCase):
     '''
@@ -233,41 +92,6 @@ class TestRenderAspectRatio(unittest.TestCase):
             _ = conv.render_aspect_ratio(None)
             self.assertEqual(ae.exception.message,
                              'Rupture aspect ratio not defined!')
-
-class TestRenderMagScaleRel(unittest.TestCase):
-    '''
-    Tests the function to render the magnitude scaling relation
-    '''
-    def setUp(self):
-        '''
-        '''
-        self.msr = WC1994()
-
-    def test_valid_mag_scale_rel(self):
-        '''
-        When input with a valid MSR class should return name of class
-        '''
-        self.assertEqual(conv.render_mag_scale_rel(self.msr), 'WC1994')
-
-
-    def test_missing_value_with_default(self):
-        '''
-        Tests the case when the attibute is missing but the use_defaults
-        option is selected
-        '''
-        self.assertAlmostEqual(
-            conv.render_mag_scale_rel(None, use_default=True),
-            'WC1994')
-
-    def test_missing_value_no_default(self):
-        '''
-        Tests the case when the attribute is missing and the use_defaults
-        option is not selected. Should raise ValueError
-        '''
-        with self.assertRaises(ValueError) as ae:
-            _ = conv.render_mag_scale_rel(None)
-            self.assertEqual(ae.exception.message,
-                             'Magnitude Scaling Relation Not Defined!')
 
 class TestRenderMSRToHazardlib(unittest.TestCase):
     """
@@ -312,94 +136,6 @@ class TestRenderMSRToHazardlib(unittest.TestCase):
                              'Magnitude Scaling Relation rubbish Defined!')
 
 
-class TestRenderNodalPlane(unittest.TestCase):
-    '''
-    Tests the rendering of the models.NodalPlane
-    '''
-    def setUp(self):
-        '''
-        '''
-        self.npd_as_list = [models.NodalPlane(0.5, 0., 90., 0.),
-                            models.NodalPlane(0.5, 90., 90., 180.)]
-
-        self.npd_as_pmf = PMF([(0.5, NodalPlane(0., 90., 0.)),
-                               (0.5, NodalPlane(90., 90., 180.))])
-
-        self.npd_as_pmf_bad = PMF([(0.5, None),
-                                    (0.5, NodalPlane(90., 90., 180.))])
-
-    def test_render_nodal_planes_as_list(self):
-        '''
-        Tests the workflow when nodal planes already input as a list of
-        models.NodalPlane class
-        '''
-        output = conv.render_npd(self.npd_as_list)
-        self.assertAlmostEqual(output[0].probability, 0.5)
-        self.assertAlmostEqual(output[0].strike, 0.)
-        self.assertAlmostEqual(output[0].dip, 90.)
-        self.assertAlmostEqual(output[0].rake, 0.)
-        self.assertAlmostEqual(output[1].probability, 0.5)
-        self.assertAlmostEqual(output[1].strike, 90.)
-        self.assertAlmostEqual(output[1].dip, 90.)
-        self.assertAlmostEqual(output[1].rake, 180.)
-
-    def test_render_nodal_planes_as_pmf_good(self):
-        '''
-        Tests the workflow when nodal planes input as a PMF
-        '''
-        output = conv.render_npd(self.npd_as_pmf)
-        self.assertAlmostEqual(output[0].probability, 0.5)
-        self.assertAlmostEqual(output[0].strike, 0.)
-        self.assertAlmostEqual(output[0].dip, 90.)
-        self.assertAlmostEqual(output[0].rake, 0.)
-        self.assertAlmostEqual(output[1].probability, 0.5)
-        self.assertAlmostEqual(output[1].strike, 90.)
-        self.assertAlmostEqual(output[1].dip, 90.)
-        self.assertAlmostEqual(output[1].rake, 180.)
-
-    def test_render_nodal_planes_as_pmf_bad_1(self):
-        '''
-        Tests the workflow when nodal planes input as a PMF without instance
-        of openquake.hazardlib.geo.nodal_plane.NodalPlane :class:
-        '''
-        with self.assertRaises(ValueError) as ae:
-            output = conv.render_npd(self.npd_as_pmf_bad)
-            self.assertEqual(ae.exception.message,
-                'Nodal Planes incorrectly formatted!')
-
-    def test_render_nodal_planes_as_pmf_bad_2(self):
-        '''
-        Tests the workflow when nodal planes input as a PMF without
-        probabilities summing to 1.0
-        '''
-        self.npd_as_pmf.data[1] = (0.4, NodalPlane(90., 90., 180.))
-        with self.assertRaises(ValueError) as ae:
-            output = conv.render_npd(self.npd_as_pmf)
-            self.assertEqual(ae.exception.message,
-                'Nodal Plane probabilities do not sum to 1.0')
-
-    def test_render_nodal_planes_null_default(self):
-        '''
-        Tests the rendering of the nodal planes when no input is specified,
-        but the use_defaults is on.
-        '''
-        output = conv.render_npd(None, use_default=True)
-        self.assertAlmostEqual(output[0].probability, 1.0)
-        self.assertAlmostEqual(output[0].strike, 0.)
-        self.assertAlmostEqual(output[0].dip, 90.)
-        self.assertAlmostEqual(output[0].rake, 0.)
-
-    def test_render_nodal_planes_null(self):
-        '''
-        Tests the rendering of the nodal planes when no input is specified
-        and no defaults are permitted. Should raise ValueError
-        '''
-        with self.assertRaises(ValueError) as ae:
-            output = conv.render_npd(None)
-            self.assertEqual(ae.exception.message,
-                'Nodal Plane distribution not defined')
-
-
 class TestNPDtoPMF(unittest.TestCase):
     """
     Tests the function to convert the nodal plane distribution to the :class:
@@ -408,8 +144,8 @@ class TestNPDtoPMF(unittest.TestCase):
     def setUp(self):
         """
         """
-        self.npd_as_list = [models.NodalPlane(0.5, 0., 90., 0.),
-                            models.NodalPlane(0.5, 90., 90., 180.)]
+        #~ self.npd_as_list = [models.NodalPlane(0.5, 0., 90., 0.),
+                            #~ models.NodalPlane(0.5, 90., 90., 180.)]
         self.npd_as_pmf = PMF([(0.5, NodalPlane(0., 90., 0.)),
                                (0.5, NodalPlane(90., 90., 180.))])
 
@@ -421,20 +157,6 @@ class TestNPDtoPMF(unittest.TestCase):
         Tests the case when a PMF is already input
         """
         output = conv.npd_to_pmf(self.npd_as_pmf)
-        self.assertAlmostEqual(output.data[0][0], 0.5)
-        self.assertAlmostEqual(output.data[0][1].strike, 0.)
-        self.assertAlmostEqual(output.data[0][1].dip, 90.)
-        self.assertAlmostEqual(output.data[0][1].rake, 0.)
-        self.assertAlmostEqual(output.data[1][0], 0.5)
-        self.assertAlmostEqual(output.data[1][1].strike, 90.)
-        self.assertAlmostEqual(output.data[1][1].dip, 90.)
-        self.assertAlmostEqual(output.data[1][1].rake, 180.)
-
-    def test_class_as_list(self):
-        """
-        Tests the case when a PMF is already input
-        """
-        output = conv.npd_to_pmf(self.npd_as_list)
         self.assertAlmostEqual(output.data[0][0], 0.5)
         self.assertAlmostEqual(output.data[0][1].strike, 0.)
         self.assertAlmostEqual(output.data[0][1].dip, 90.)
@@ -465,72 +187,6 @@ class TestNPDtoPMF(unittest.TestCase):
                 'Nodal Plane distribution not defined')
 
 
-class TestRenderHypoDepth(unittest.TestCase):
-    '''
-    Tests the rendering of the hypocentral depth distribution
-    '''
-    def setUp(self):
-        '''
-        '''
-        self.depth_as_list = [models.HypocentralDepth(0.5, 5.),
-                              models.HypocentralDepth(0.5, 10.)]
-
-        self.depth_as_pmf = PMF([(0.5, 5.), (0.5, 10.)])
-
-    def test_good_instance_list(self):
-        '''
-        Tests good output when list of instances of :class:
-        models.HypocentralDepth are passed
-        '''
-        output = conv.render_hdd(self.depth_as_list)
-        self.assertAlmostEqual(output[0].probability, 0.5)
-        self.assertAlmostEqual(output[0].depth, 5.)
-        self.assertAlmostEqual(output[1].probability, 0.5)
-        self.assertAlmostEqual(output[1].depth, 10.)
-
-    def test_good_instance_pmf(self):
-        '''
-        Tests good output when openquake.hazardlib.pmf.PMF class is passed
-        '''
-        output = conv.render_hdd(self.depth_as_pmf)
-        self.assertAlmostEqual(output[0].probability, 0.5)
-        self.assertAlmostEqual(output[0].depth, 5.)
-        self.assertAlmostEqual(output[1].probability, 0.5)
-        self.assertAlmostEqual(output[1].depth, 10.)
-
-    def test_bad_instance_pmf(self):
-        '''
-        Tests function when openquake.hazardlib.pmf.PMF class is passed
-        with probabilities not equal to 1.0. Should raise ValueError
-        '''
-        self.depth_as_pmf.data[1] = (0.4, 10.)
-        with self.assertRaises(ValueError) as ae:
-            output = conv.render_hdd(self.depth_as_pmf)
-            self.assertEqual(ae.exception.message,
-                'Hypocentral depth distribution probabilities do not sum to '
-                '1.0')
-
-    def test_no_input_with_defaults(self):
-        '''
-        Tests hypocentral depth distribution renderer when no input is
-        supplied but the user opts to accept defaults
-        '''
-        output = conv.render_hdd(None, use_default=True)
-        self.assertAlmostEqual(output[0].probability, 1.0)
-        self.assertAlmostEqual(output[0].depth, 10.0)
-
-    def test_no_input_without_defaults(self):
-        '''
-        Tests hypocentral depth distribution renderer when no input is
-        supplied but the user does not accept defaults. Should raise
-        ValueError
-        '''
-        with self.assertRaises(ValueError) as ae:
-            output = conv.render_hdd(None)
-            self.assertEqual(ae.exception.message,
-                'Hypocentral depth distribution not defined!')
-
-
 class TestHDDtoHazardlib(unittest.TestCase):
     """
     Class to test the function hdd_to_pmf, which converts the hypocentral
@@ -539,8 +195,8 @@ class TestHDDtoHazardlib(unittest.TestCase):
     def setUp(self):
         """
         """
-        self.depth_as_list = [models.HypocentralDepth(0.5, 5.),
-                              models.HypocentralDepth(0.5, 10.)]
+        #~ self.depth_as_list = [models.HypocentralDepth(0.5, 5.),
+                              #~ models.HypocentralDepth(0.5, 10.)]
 
         self.depth_as_pmf = PMF([(0.5, 5.), (0.5, 10.)])
 
@@ -549,18 +205,6 @@ class TestHDDtoHazardlib(unittest.TestCase):
         Tests the function when a valid PMF is input
         """
         output = conv.hdd_to_pmf(self.depth_as_pmf)
-        self.assertIsInstance(output, PMF)
-        self.assertAlmostEqual(output.data[0][0], 0.5)
-        self.assertAlmostEqual(output.data[0][1], 5.)
-        self.assertAlmostEqual(output.data[1][0], 0.5)
-        self.assertAlmostEqual(output.data[1][1], 10.)
-
-    def test_input_as_nrmllib(self):
-        """
-        Tests the function when a list of models.HypocentralDepth classes
-        are input
-        """
-        output = conv.hdd_to_pmf(self.depth_as_list)
         self.assertIsInstance(output, PMF)
         self.assertAlmostEqual(output.data[0][0], 0.5)
         self.assertAlmostEqual(output.data[0][1], 5.)
@@ -621,18 +265,3 @@ class TestConvertSourceGeometries(unittest.TestCase):
         self.assertEqual(
             conv.simple_edge_to_wkt_linestring(self.simple_edge),
             expected)
-
-
-    def test_complex_trace_to_wkt(self):
-        '''
-        Tests the conversion of a list of instances of the :class:
-        openquake.hazardlib.geo.line.Line to :class:
-        models.ComplexFaultGeometry
-        '''
-        model = conv.complex_trace_to_wkt_linestring(self.complex_edge)
-        self.assertEqual(model.top_edge_wkt,
-                        'LINESTRING (10.5 10.5 1.0, 11.35 11.45 2.0)')
-        self.assertListEqual(model.int_edges,
-                             ['LINESTRING (10.5 10.5 20.0, 11.35 11.45 21.0)'])
-        self.assertEqual(model.bottom_edge_wkt,
-                        'LINESTRING (10.5 10.5 40.0, 11.35 11.45 40.0)')

--- a/tests/sources/test_source_model.py
+++ b/tests/sources/test_source_model.py
@@ -115,8 +115,8 @@ class TestSourceModel(unittest.TestCase):
             orig_source = source_model.sources[i]
             test_source = source_model_test.sources[i]
             self.assertEqual(orig_source.name, test_source.name)
-            self.assertEqual(orig_source.mag_scale_rel,
-                             test_source.mag_scale_rel)
+            self.assertEqual(orig_source.mag_scale_rel.__class__.__name__,
+                             test_source.mag_scale_rel.__class__.__name__)
             #print orig_source.__dict__, test_source.__dict__
             #self.assertDictEqual(orig_source.__dict__, test_source.__dict__)
         # Remove the test file


### PR DESCRIPTION
Removes all dependency on oq-nrmllib.
1. Re-writes nrml04 source model parsers using oq-commonlib version (with partial validation)
2. Removes all methods for creating a nrmllib source from source model classes
3. Updates tests