### PR TITLE
(Yet another) fix to Weichert plus cleanup of  occurence utils and recurrence plots

### DIFF
--- a/hmtk/seismicity/occurrence/weichert.py
+++ b/hmtk/seismicity/occurrence/weichert.py
@@ -49,7 +49,9 @@ import warnings
 import numpy as np
 from hmtk.seismicity.occurrence.base import (
     SeismicityOccurrence, OCCURRENCE_METHODS)
-from hmtk.seismicity.occurrence.utils import input_checks
+from hmtk.seismicity.occurrence.utils import (input_checks,
+                                              get_completeness_counts)
+                                              
 
 
 @OCCURRENCE_METHODS.add(
@@ -78,7 +80,8 @@ class Weichert(SeismicityOccurrence):
             start_year = float(np.min(catalogue.data["year"]))
             completeness = np.column_stack([ctime, cmag])
         # Apply Weichert preparation
-        cent_mag, t_per, n_obs = self._weichert_prep(catalogue, completeness)
+        cent_mag, t_per, n_obs = get_completeness_counts(
+            catalogue, completeness, config["magnitude_interval"])
 
         # A few more Weichert checks
         key_list = config.keys()
@@ -97,63 +100,6 @@ class Weichert(SeismicityOccurrence):
             sigma_rate = np.log10(aval + sigma_a) - np.log10(aval)
 
         return bval, sigma_b, rate, sigma_rate
-
-    def _weichert_prep(self, catalogue, completeness):
-        """
-        Allows to prepare table input for Weichert algorithm
-
-        :param year: catalog matrix year column
-        :type year: numpy.ndarray
-        :param magnitude: catalog matrix magnitude column
-        :type magnitude: numpy.ndarray
-        :param ctime: year of completeness for each period
-        :type ctime: numpy.ndarray
-        :param cmag: completeness magnitude for each period
-        :type cmag: numpy.ndarray
-        :param dmag: magnitude bin size (config file)
-        :type dmag: positive float
-        :param dtime: time bin size from config file)
-
-        :type dtime: float
-        :returns: central magnitude, tper length of observation period,
-                  n_obs number of events in magnitude increment
-        """
-        mmax_obs = np.max(catalogue.data["magnitude"])
-        if mmax_obs > np.max(completeness[:, 1]):
-            cmag = np.hstack([completeness[:, 1], mmax_obs + 1.0E-10])
-            high_event = True
-        else:
-            high_event = False
-            cmag = np.hstack([completeness[:, 1],
-                              completeness[-1, 1] + 1.0E-10])
-            
-        cyear = np.hstack([catalogue.end_year + 1, completeness[:, 0]])
-        count_table = np.zeros([len(cmag) - 1, len(cyear) - 1])
-        nmx, nmt = count_table.shape
-        count_years = np.zeros_like(count_table)
-        for i in range(len(cyear) - 1):
-            time_idx = np.logical_and(catalogue.data["dtime"] < cyear[i],
-                                      catalogue.data["dtime"] >= cyear[i + 1])
-            nyrs = cyear[i] - cyear[i + 1]
-            sel_mags = catalogue.data["magnitude"][time_idx]
-            for j in range(i, len(cmag) - 1):
-                mag_idx = np.logical_and(sel_mags >= cmag[j],
-                                         sel_mags < cmag[j + 1])
-                count_table[j, i] += float(np.sum(mag_idx))
-                count_years[j, i] += float(nyrs)
-        if not high_event:
-            # Remove last row
-            delta = delta[:-1]
-            count_table = count_table[:-1, :]
-            count_years = count_years[:-1, :]
-            nmx -= 1
-            nmt -= 1
-        cent_mag = (cmag[:-1] + cmag[1:]) / 2.
-        #print cent_mag, count_table, count_years
-        t_per = np.sum(count_years, axis=1)
-        n_obs = np.sum(count_table, axis=1)
-        #print t_per, n_obs
-        return cent_mag, t_per, n_obs
 
     def weichert_algorithm(self, tper, fmag, nobs, mrate=0.0, bval=1.0,
                            itstab=1E-5, maxiter=1000):
@@ -221,69 +167,3 @@ class Weichert(SeismicityOccurrence):
                     return np.nan, np.nan, np.nan, np.nan, np.nan, np.nan
         return bval, sigb, a_m, siga_m, fn0, stdfn0
 
-
-#    def _weichert_prep(self, year, magnitude, ctime, cmag, dmag, dtime=1.0):
-#        """
-#        Allows to prepare table input for Weichert algorithm
-#
-#        :param year: catalog matrix year column
-#        :type year: numpy.ndarray
-#        :param magnitude: catalog matrix magnitude column
-#        :type magnitude: numpy.ndarray
-#        :param ctime: year of completeness for each period
-#        :type ctime: numpy.ndarray
-#        :param cmag: completeness magnitude for each period
-#        :type cmag: numpy.ndarray
-#        :param dmag: magnitude bin size (config file)
-#        :type dmag: positive float
-#        :param dtime: time bin size from config file)
-#
-#        :type dtime: float
-#        :returns: central magnitude, tper length of observation period,
-#                  n_obs number of events in magnitude increment
-#        """
-#
-#        # In the case that the user defines a single value for ctime or cmag
-#        # that is not an array
-#        if not(isinstance(ctime, np.ndarray)) and not(isinstance(ctime, list)):
-#            ctime = np.array([ctime])
-#        if not(isinstance(cmag, np.ndarray)) and not(isinstance(cmag, list)):
-#            cmag = np.array([cmag])
-#        valid_events = np.ones(np.shape(year)[0], dtype=bool)
-#        # Remove events from catalogue below completeness intervals
-#        mag_eq_tolerance = dmag / 1.E7
-#        time_tolerance = dtime / 1.E7
-#
-#        for iloc, mag in enumerate(cmag):
-#            index0 = np.logical_and(magnitude < (mag - mag_eq_tolerance),
-#                                    year < (ctime[iloc] - time_tolerance))
-#            valid_events[index0] = False
-#
-#        year = year[valid_events]
-#        magnitude = magnitude[valid_events]
-#
-#        mag_range = np.arange(np.min(magnitude) - dmag / 2.,
-#                              np.max(magnitude) + (2.0 * dmag), dmag)
-#        time_range = np.arange(np.min(year) - dtime / 2.,
-#                               np.max(year) + (2.0 * dtime),
-#                               dtime)
-#
-#        # Histogram data
-#        fullcount1 = np.histogram2d(year, magnitude,
-#                                    bins=[time_range, mag_range])[0]
-#        n_y = np.shape(fullcount1)[1] - 1
-#        cent_mag = ((mag_range[:-1] + mag_range[1:]) / 2.)[:-1]
-#
-#        n_obs = np.sum(fullcount1, axis=0)[:-1]
-#        t_per = np.zeros(n_y)
-#        for iloc, mag in enumerate(cmag):
-#            index0 = cent_mag > (mag - (dmag / 2. - mag_eq_tolerance))
-#            t_per[index0] = np.max(year) - ctime[iloc] + 1
-#
-#        #cut off magnitudes below the lowest magnitude of completeness
-#        valid_location = np.nonzero(t_per)[0][0]
-#        cent_mag = cent_mag[valid_location:]
-#        t_per = t_per[valid_location:]
-#        n_obs = n_obs[valid_location:]
-#
-#        return cent_mag, t_per, n_obs

--- a/tests/seismicity/occurrence/weichert_test.py
+++ b/tests/seismicity/occurrence/weichert_test.py
@@ -148,20 +148,6 @@ class WeichertTestCase(unittest.TestCase):
                                       [1930., 6.0],
                                       [1910., 7.0]])
 
-    def test_weichert_prep(self):
-        """
-        Tests the Weichert preparation function to ensure the correct counts
-        """
-        wchrt = Weichert()
-        expected_mags = np.array([3.5, 4.5, 5.5, 6.5, 7.06])
-        expected_count = np.array([1749., 391., 72., 13., 1.])
-        expected_tper = np.array([20., 35., 50., 80.,100.])
-        cent_mag, t_per, n_obs = wchrt._weichert_prep(self.catalogue,
-                                                      self.completeness)
-        np.testing.assert_array_almost_equal(cent_mag, expected_mags)
-        np.testing.assert_array_almost_equal(t_per, expected_tper)
-        np.testing.assert_array_almost_equal(n_obs, expected_count)
-
     def test_weichert_full(self):
         """
         Tests the Weichert function for the synthetic catalogue
@@ -170,7 +156,7 @@ class WeichertTestCase(unittest.TestCase):
         bval, sigmab, rate, sigma_rate = wchrt.calculate(self.catalogue,
                                                          self.config,
                                                          self.completeness)
-        self.assertAlmostEqual(bval, 0.905, 3)
-        self.assertAlmostEqual(sigmab, 0.0165, 4)
-        self.assertAlmostEqual(rate, 100.350, 3)
-        self.assertAlmostEqual(sigma_rate, 2.1269, 3) 
+        self.assertAlmostEqual(bval, 0.890, 3)
+        self.assertAlmostEqual(sigmab, 0.015, 3)
+        self.assertAlmostEqual(rate, 100.1078, 4)
+        self.assertAlmostEqual(sigma_rate, 2.1218, 4) 


### PR DESCRIPTION
The previous PR introduced a small bug into the Weichert methodology when provided with a single row completeness table. After further investigation this prompted a revision of the method fo counting the total rate of events within each completeness window. New code removes the _weichert_prep function and replaces with a method in the hmtk/seismicity/occurence/utils.py module called get_completeness_counts. The same method is used both by Weichert and by the recurrence plots.