### PR TITLE
Add support for eventID as strings + PEP8 fixes + Fix source parsing …

### DIFF
--- a/hmtk/seismicity/catalogue.py
+++ b/hmtk/seismicity/catalogue.py
@@ -69,10 +69,10 @@ class Catalogue(object):
         'SemiMajor90', 'SemiMinor90', 'ErrorStrike', 'depth',
         'depthError', 'magnitude', 'sigmaMagnitude']
 
-    INT_ATTRIBUTE_LIST = ['eventID', 'year', 'month', 'day', 'hour', 'minute',
+    INT_ATTRIBUTE_LIST = ['year', 'month', 'day', 'hour', 'minute',
                           'flag']
 
-    STRING_ATTRIBUTE_LIST = ['Agency', 'magnitudeType', 'comment']
+    STRING_ATTRIBUTE_LIST = ['eventID', 'Agency', 'magnitudeType', 'comment']
 
     TOTAL_ATTRIBUTE_LIST = list(
         (set(FLOAT_ATTRIBUTE_LIST).union(
@@ -143,7 +143,7 @@ class Catalogue(object):
                 self.data[key] = data_array[:, i].astype(int)
             else:
                 self.data[key] = data_array[:, i]
-            if not key in self.TOTAL_ATTRIBUTE_LIST:
+            if key not in self.TOTAL_ATTRIBUTE_LIST:
                 print 'Key %s not a recognised catalogue attribute' % key
 
         self.update_end_year()
@@ -416,12 +416,11 @@ class Catalogue(object):
             normalisation=normalisation,
             number_bootstraps=bootstrap)
 
-        
     def concatenate(self, catalogue):
         """
         This method attaches one catalogue to the current one
 
-        :parameter catalogue: 
+        :parameter catalogue:
             An instance of :class:`htmk.seismicity.catalogue.Catalogue`
         """
 
@@ -452,6 +451,7 @@ class Catalogue(object):
                     raise ValueError('unknown attibute')
         self.sort_catalogue_chronologically()
 
+
 def _merge_data(dat1, dat2):
     """
     Merge two data dictionaries containing catalogue data
@@ -461,9 +461,9 @@ def _merge_data(dat1, dat2):
 
     :parameter dictionary dat2:
         Catalogue data dictionary
-        
+
     :returns:
-        A catalogue data dictionary containing the information originally 
+        A catalogue data dictionary containing the information originally
         included in dat1 and dat2
     """
 
@@ -475,14 +475,14 @@ def _merge_data(dat1, dat2):
             cnt += 1
 
     if cnt:
-        raise Warning('Cannot merge catalogues with different' + 
+        raise Warning('Cannot merge catalogues with different' +
                       ' attributes')
         return None
-    else: 
+    else:
         for key in dat1.keys():
-            if isinstance(dat1[key], np.ndarray): 
+            if isinstance(dat1[key], np.ndarray):
                 dat1[key] = np.concatenate((dat1[key], dat2[key]), axis=0)
-            elif isinstance(dat1[key], list): 
+            elif isinstance(dat1[key], list):
                 dat1[key] += dat2[key]
             else:
                 raise ValueError('Unknown type')

--- a/tests/parsers/catalogue/csv_catalogue_parser_test.py
+++ b/tests/parsers/catalogue/csv_catalogue_parser_test.py
@@ -9,18 +9,18 @@
 #
 # The Hazard Modeller's Toolkit is free software: you can redistribute
 # it and/or modify it under the terms of the GNU Affero General Public
-# License as published by the Free Software Foundation, either version
-# 3 of the License, or (at your option) any later version.
+# License as published by the Free Software Foundation, either version
+# 3 of the License, or (at your option) any later version.
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>
 #
-# DISCLAIMER
-# 
+# DISCLAIMER
+#
 # The software Hazard Modeller's Toolkit (hmtk) provided herein
-# is released as a prototype implementation on behalf of
+# is released as a prototype implementation on behalf of
 # scientists and engineers working within the GEM Foundation (Global
-# Earthquake Model).
+# Earthquake Model).
 #
 # It is distributed for the purpose of open collaboration and in the
 # hope that it will be useful to the scientific, engineering, disaster
@@ -38,9 +38,9 @@
 # (hazard@globalquakemodel.org).
 #
 # The Hazard Modeller's Toolkit (hmtk) is therefore distributed WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
-# for more details.
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# for more details.
 #
 # The GEM Foundation, and the authors of the software, assume no
 # liability for use of the software.
@@ -51,7 +51,6 @@ import numpy as np
 from hmtk.seismicity.catalogue import Catalogue
 from hmtk.parsers.catalogue.csv_catalogue_parser import (CsvCatalogueParser,
                                                          CsvCatalogueWriter)
-
 
 
 class CsvCatalogueParserTestCase(unittest.TestCase):
@@ -75,7 +74,7 @@ class CsvCatalogueParserTestCase(unittest.TestCase):
         Check that the some fields in the first row of the catalogue are read
         correctly
         """
-        self.assertEqual(self.cat.data['eventID'][0], 54)
+        self.assertEqual(self.cat.data['eventID'][0], '54')
         self.assertEqual(self.cat.data['Agency'][0], 'sheec')
         self.assertEqual(self.cat.data['year'][0], 1011)
 
@@ -84,7 +83,7 @@ class CsvCatalogueParserTestCase(unittest.TestCase):
         Check that the number of earthquakes read form the catalogue is
         correct
         """
-        self.assertEqual(self.cat.get_number_events(),8)
+        self.assertEqual(self.cat.get_number_events(), 8)
 
     def test_without_specifying_years(self):
         """
@@ -110,9 +109,6 @@ class CsvCatalogueParserTestCase(unittest.TestCase):
         self.assertEqual(self.cat.end_year, 1100)
 
 
-
-
-
 class TestCsvCatalogueWriter(unittest.TestCase):
     '''
     Tests the catalogue csv writer
@@ -124,21 +120,23 @@ class TestCsvCatalogueWriter(unittest.TestCase):
                                             'TEST_OUTPUT_CATALOGUE.csv')
         print self.output_filename
         self.catalogue = Catalogue()
-        self.catalogue.data['eventID'] = np.array([1, 2, 3, 4, 5])
+        self.catalogue.data['eventID'] = ['1', '2', '3', '4', '5']
         self.catalogue.data['magnitude'] = np.array([5.6, 5.4, 4.8, 4.3, 5.])
         self.catalogue.data['year'] = np.array([1960, 1965, 1970, 1980, 1990])
         self.catalogue.data['ErrorStrike'] = np.array([np.nan, np.nan, np.nan,
                                                        np.nan, np.nan])
-        self.magnitude_table =  np.array([[1990., 4.5], [1970., 5.5]])
+        self.magnitude_table = np.array([[1990., 4.5], [1970., 5.5]])
         self.flag = np.array([1, 1, 1, 1, 0], dtype=bool)
-
 
     def check_catalogues_are_equal(self, cat1, cat2):
         '''
         Compares two catalogues
         '''
-        np.testing.assert_array_equal(cat1.data['eventID'],
-                                      cat2.data['eventID'])
+        for key1, key2 in zip(cat1.data['eventID'], cat2.data['eventID']):
+            print key1, key2
+            assert key1 == key2
+        # np.testing.assert_array_equal(cat1.data['eventID'],
+        #                              cat2.data['eventID'])
         np.testing.assert_array_equal(cat1.data['year'],
                                       cat2.data['year'])
 
@@ -167,7 +165,7 @@ class TestCsvCatalogueWriter(unittest.TestCase):
         cat2 = parser.read_file()
 
         expected_catalogue = Catalogue()
-        expected_catalogue.data['eventID'] = np.array([1, 2, 3, 4])
+        expected_catalogue.data['eventID'] = ['1', '2', '3', '4']
         expected_catalogue.data['magnitude'] = np.array([5.6, 5.4, 4.8, 4.3])
         expected_catalogue.data['year'] = np.array([1960, 1965, 1970, 1980])
         expected_catalogue.data['ErrorStrike'] = np.array([np.nan, np.nan,
@@ -185,10 +183,10 @@ class TestCsvCatalogueWriter(unittest.TestCase):
         cat2 = parser.read_file()
 
         expected_catalogue = Catalogue()
-        expected_catalogue.data['eventID'] = np.array([1, 3, 5])
+        expected_catalogue.data['eventID'] = ['1', '3', '5']
         expected_catalogue.data['magnitude'] = np.array([5.6, 4.8, 5.0])
         expected_catalogue.data['year'] = np.array([1960, 1970, 1990])
-        expected_catalogue.data['ErrorStrike'] =np.array([np.nan, np.nan,
+        expected_catalogue.data['ErrorStrike'] = np.array([np.nan, np.nan,
                                                           np.nan])
         self.check_catalogues_are_equal(expected_catalogue, cat2)
 
@@ -206,12 +204,11 @@ class TestCsvCatalogueWriter(unittest.TestCase):
         cat2 = parser.read_file()
 
         expected_catalogue = Catalogue()
-        expected_catalogue.data['eventID'] =  np.array([1, 3])
+        expected_catalogue.data['eventID'] = ['1', '3']
         expected_catalogue.data['magnitude'] = np.array([5.6, 4.8])
         expected_catalogue.data['year'] = np.array([1960, 1970])
         expected_catalogue.data['ErrorStrike'] = np.array([np.nan, np.nan])
         self.check_catalogues_are_equal(expected_catalogue, cat2)
-
 
     def tearDown(self):
         '''


### PR DESCRIPTION
This PR sets the catalogue EventID field as a string. I also fixed a number of very minor PEP8 issues and the parsing of a source model that was no longer working (although I'm not sure if this parsing procedure is covered by a test see https://github.com/GEMScienceTools/hmtk/blob/id_as_string/hmtk/comparison/rate_grids.py#L135)

